### PR TITLE
Fix: pin dids on openDB and resolve them with did-resolver.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "3box-pinning-server",
-  "version": "1.1.1",
+  "name": "3box-pinning-node",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2242,7 +2242,7 @@
         "datastore-core": "~0.6.0",
         "encoding-down": "^5.0.4",
         "interface-datastore": "~0.6.0",
-        "level-js": "github:timkuijsten/level.js#idbunwrapper",
+        "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
         "leveldown": "^3.0.2",
         "levelup": "^2.0.2",
         "pull-stream": "^3.6.9"
@@ -2534,6 +2534,11 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
+    },
+    "did-resolver": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-0.0.6.tgz",
+      "integrity": "sha512-PqxzaoomTbJG3IzEouUGgppu3xrsbGKHS75zS3vS/Hfm56XxLpwIe7yFLokgXUbMWmLa0dczFHOibmebO4wRLA=="
     },
     "diff": {
       "version": "3.5.0",
@@ -3956,8 +3961,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3981,15 +3985,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4006,22 +4008,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4152,8 +4151,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4167,7 +4165,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4184,7 +4181,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4193,15 +4189,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4222,7 +4216,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4311,8 +4304,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4326,7 +4318,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4422,8 +4413,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4465,7 +4455,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4487,7 +4476,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4536,15 +4524,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4619,8 +4605,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4638,13 +4623,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4657,18 +4640,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4771,8 +4751,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4782,7 +4761,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4795,20 +4773,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4825,7 +4800,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4905,8 +4879,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4916,7 +4889,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4992,8 +4964,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5018,7 +4989,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5036,7 +5006,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5075,13 +5044,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -6013,7 +5980,7 @@
                 "protons": "^1.0.1",
                 "rsa-pem-to-jwk": "^1.1.3",
                 "tweetnacl": "^1.0.0",
-                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
               },
               "dependencies": {
                 "webcrypto-shim": {
@@ -8270,7 +8237,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -8347,7 +8314,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -8424,7 +8391,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -8490,7 +8457,7 @@
         "rsa-pem-to-jwk": "^1.1.3",
         "tweetnacl": "^1.0.0",
         "ursa-optional": "~0.9.9",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
       }
     },
     "libp2p-crypto-secp256k1": {
@@ -8562,7 +8529,7 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "ursa-optional": "~0.9.9",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -8607,7 +8574,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -8704,7 +8671,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "multihashing-async": {
@@ -8815,7 +8782,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -8942,7 +8909,7 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "ursa-optional": "~0.9.9",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -8988,7 +8955,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
         "multihashing-async": {
@@ -9062,7 +9029,7 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "ursa-optional": "~0.9.9",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -9100,7 +9067,7 @@
                 "protons": "^1.0.1",
                 "rsa-pem-to-jwk": "^1.1.3",
                 "tweetnacl": "^1.0.0",
-                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
               },
               "dependencies": {
                 "webcrypto-shim": {
@@ -9174,7 +9141,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -9237,7 +9204,7 @@
         "socket.io": "^2.1.1",
         "socket.io-client": "^2.1.1",
         "stream-to-pull-stream": "^1.7.2",
-        "webrtcsupport": "github:ipfs/webrtcsupport"
+        "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
       },
       "dependencies": {
         "debug": {
@@ -9265,7 +9232,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -9366,7 +9333,7 @@
                 "rsa-pem-to-jwk": "^1.1.3",
                 "tweetnacl": "^1.0.0",
                 "ursa-optional": "~0.9.9",
-                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
               },
               "dependencies": {
                 "webcrypto-shim": {
@@ -10143,6 +10110,14 @@
         "varint": "^5.0.0"
       }
     },
+    "muport-did-resolver": {
+      "version": "0.3.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/muport-did-resolver/-/muport-did-resolver-0.3.0-alpha.3.tgz",
+      "integrity": "sha512-rT7/ZzeAqAnfHvKbh+fdwxQjr/KFVLzVm2vViAJ+RCOhTTFd/LGgQAH+5uvXHFWN3wlF6XZWRARVDmHopIjcLQ==",
+      "requires": {
+        "did-resolver": "0.0.6"
+      }
+    },
     "murmurhash3js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
@@ -10284,7 +10259,7 @@
     },
     "node-localstorage": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
       "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
       "requires": {
         "write-file-atomic": "^1.1.4"
@@ -10914,7 +10889,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -10982,7 +10957,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {
@@ -11038,7 +11013,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           },
           "dependencies": {
             "webcrypto-shim": {

--- a/package.json
+++ b/package.json
@@ -25,14 +25,16 @@
   "dependencies": {
     "analytics-node": "^3.3.0",
     "axios": "^0.18.0",
+    "did-resolver": "0.0.6",
     "dotenv": "^6.2.0",
     "exectimer": "^2.2.1",
     "express": "^4.16.4",
     "get-folder-size": "^2.0.0",
     "ipfs": "^0.33.1",
-    "orbit-db": "git://github.com/orbitdb/orbit-db.git#9d674766a54c7b949eca0d7e5ddc26b5486717cd",
     "js-sha256": "^0.9.0",
     "multihashes": "^0.4.14",
+    "muport-did-resolver": "^0.3.0-alpha.3",
+    "orbit-db": "git://github.com/orbitdb/orbit-db.git#9d674766a54c7b949eca0d7e5ddc26b5486717cd",
     "redis": "^2.8.0",
     "yargs": "^12.0.5"
   },

--- a/src/__tests__/didSupport.test.js
+++ b/src/__tests__/didSupport.test.js
@@ -23,7 +23,6 @@ const IPFS_CONF = {
 }
 
 const DID = 'did:muport:QmNQLKvMqGrDCrzmFS2C5p2JaRZ7bk6DqY7RJinhJoVxVT'
-const IPFS_ADDR = 'QmNQLKvMqGrDCrzmFS2C5p2JaRZ7bk6DqY7RJinhJoVxVT'
 const COMPRESSED_KEY = '02d1f48e3d5c52954a01f1aa104bad1a22e2eed6ecbd4961737fbffa8d75457cd4'
 const UNCOMPRESSED_KEY = '04d1f48e3d5c52954a01f1aa104bad1a22e2eed6ecbd4961737fbffa8d75457cd4ab9b98ef29b96c6a1bbc54c2b9ded4ea6e803c50201c38c017b7b34c7a2451e8'
 const MANIFEST = '{"version":1,"signingKey":"02d1f48e3d5c52954a01f1aa104bad1a22e2eed6ecbd4961737fbffa8d75457cd4","managementKey":"0x3334d0c1fd88529a1285a5f3c9cd71b382684073","asymEncryptionKey":"/MklZEmpCWWbUL/n5qnzLfEo6K0rtrtOrp60qNzrgVU="}'
@@ -34,18 +33,9 @@ describe('basic low level functions are working', () => {
     expect(Util.uncompressSECP256K1Key(COMPRESSED_KEY)).toEqual(UNCOMPRESSED_KEY)
   })
 
-  test('extract ipfs address from a DID', () => {
-    expect(Util.didExtractIPFSAddress(DID)).toEqual(IPFS_ADDR)
-    expect(() => Util.didExtractIPFSAddress(null)).toThrow()
-    expect(() => Util.didExtractIPFSAddress('some-string')).toThrow()
-    expect(() => Util.didExtractIPFSAddress('some:string:Qm12')).toThrow()
-    expect(() => Util.didExtractIPFSAddress('did:some-scheme:Qm12')).toThrow()
-    expect(() => Util.didExtractIPFSAddress('did:muport:Qmé')).toThrow()
-  })
-
   test('did extract signing key', async () => {
     const ipfs = { files: { cat: jest.fn(() => Promise.resolve(MANIFEST)) } }
-    const k = await Util.didExtractSigningKey(IPFS_ADDR, ipfs)
+    const k = await Util.didExtractSigningKey(ipfs, DID)
     expect(k).toEqual('02d1f48e3d5c52954a01f1aa104bad1a22e2eed6ecbd4961737fbffa8d75457cd4')
   })
 })
@@ -57,6 +47,7 @@ describe('test with network', () => {
 
   beforeAll(async () => {
     ipfs = await makeIPFS(IPFS_CONF)
+    const res = await ipfs.files.add(Buffer.from(MANIFEST))
     orbitdb = new OrbitDB(ipfs, ODB_PATH)
   })
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -10,14 +10,7 @@ const ProfileNotFound = (message) => {
   return err
 }
 
-const InvalidDIDFormat = (did) => {
-  const err = new Error(`Invalid DID Format, expected "did:muport:Qm....", got: ${did}`)
-  err.statusCode = 400
-  return err
-}
-
 module.exports = {
   InvalidInputError,
-  ProfileNotFound,
-  InvalidDIDFormat
+  ProfileNotFound
 }

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -2,6 +2,7 @@ const IPFS = require('ipfs')
 const OrbitDB = require('orbit-db')
 const Pubsub = require('orbit-db-pubsub')
 const timer = require('exectimer')
+const { resolveDID } = require('./util')
 
 const TEN_MINUTES = 10 * 60 * 1000
 const THIRTY_MINUTES = 30 * 60 * 1000
@@ -235,6 +236,13 @@ class Pinning {
         this.analytics.trackPinDB(data.odbAddress)
       } else if (data.type === 'SYNC_DB' && data.thread) {
         this.openDB(data.odbAddress, this._sendHasResponse.bind(this))
+      }
+      if (data.did) {
+        // We resolve the DID in order to pin the ipfs object
+        try {
+          resolveDID(this.ipfs, data.did)
+          // if this throws it's not a DID
+        } catch (e) {}
       }
     }
   }


### PR DESCRIPTION
This adds the real did-resolver and uses it to resolve DIDs. It also uses it to pin DIDs that are present in the `OPEN_DB` message. 

Note that this does not solve the inability for our node to connect to infura. For this to work properly we need to send along the DID from 3box-js when we openBox. This also means that getProfile/space with DID will only work for users that have opened their DBs with the new version of the 3box-js library (if we are unable to connect to infura). However, this seems like a fair trade off in order to get this working well with the new architecture.