### PR TITLE
fix: use seconds timestamps in metadata

### DIFF
--- a/src/__tests__/pinning.test.js
+++ b/src/__tests__/pinning.test.js
@@ -11,12 +11,12 @@ const ODB_PATH_1 = './tmp/orbitdb1'
 const ODB_PATH_2 = './tmp/orbitdb2'
 
 // Data to be pushed to the store
-const PUBLIC_NAME = { timeStamp: 12, value: 'very name' }
-const PUBLIC_IMAGE = { timeStamp: 13, value: 'such picture' }
-const PRIVATE_SHH = { timeStamp: 14, value: 'many secret' }
-const PRIVATE_QUIET = { timeStamp: 15, value: 'wow!' }
+const PUBLIC_NAME = { timeStamp: 12000, value: 'very name' }
+const PUBLIC_IMAGE = { timeStamp: 13000, value: 'such picture' }
+const PRIVATE_SHH = { timeStamp: 14000, value: 'many secret' }
+const PRIVATE_QUIET = { timeStamp: 15000, value: 'wow!' }
 
-// Date we are representing (note the difference for time_S_tamp)
+// Date we are representing (note the difference for time_S_tamp and the unit, ms -> seconds)
 const PROFILE = {
   name: { timestamp: 12, value: 'very name' },
   image: { timestamp: 13, value: 'such picture' }

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -73,7 +73,8 @@ class Pinning {
 
             Object.entries(profile)
               .forEach(([k, v]) => {
-                parsedProfile[k] = { value: v.value, timestamp: v.timeStamp }
+                const timestamp = Math.floor(v.timeStamp / 1000)
+                parsedProfile[k] = { value: v.value, timestamp }
               })
 
             resolve(parsedProfile)
@@ -125,7 +126,8 @@ class Pinning {
           const parsedSpace = Object.keys(pubSpace).reduce((obj, key) => {
             if (key.startsWith('pub_')) {
               const x = pubSpace[key]
-              obj[key.slice(4)] = { value: x.value, timestamp: x.timeStamp }
+              const timestamp = Math.floor(x.timeStamp / 1000)
+              obj[key.slice(4)] = { value: x.value, timestamp }
             }
             return obj
           }, {})


### PR DESCRIPTION
Fix #128 