### PR TITLE
fix: dont throw a promise rejection if a did is invalid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10514,9 +10514,9 @@
       }
     },
     "muport-did-resolver": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/muport-did-resolver/-/muport-did-resolver-0.3.0.tgz",
-      "integrity": "sha512-0ZOEKM1qqMvVFWpJW1sD+A8SPg/jftfXzIq2S5OmQmAca6LWna0uYqFrZN3ncN3hZbAFSqn+xUcjfvA77DUcDw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muport-did-resolver/-/muport-did-resolver-0.3.1.tgz",
+      "integrity": "sha512-xS2MmjLGrXR+7bN5iiLwn+yXLVTIB8mTHVefuDKtJ7BmrwVpTdLJOsVGETsPnIM1lps8JK7WPjjGpmA/NLIMfQ==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "did-resolver": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ipfs": "^0.36.4",
     "js-sha256": "^0.9.0",
     "multihashes": "^0.4.14",
-    "muport-did-resolver": "^0.3.0",
+    "muport-did-resolver": "^0.3.1",
     "orbit-db": "^0.21.3",
     "orbit-db-cache-redis": "0.0.3",
     "redis": "^2.8.0",

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -45,11 +45,11 @@ const rejectOnError = (reject, f) => {
   }
 }
 
-const pinDID = did => {
+const pinDID = async did => {
   if (!did) return
   // We resolve the DID in order to pin the ipfs object
   try {
-    resolveDID(did)
+    await resolveDID(did)
     // if this throws it's not a DID
   } catch (e) {}
 }


### PR DESCRIPTION
Just a small fix that makes invalid DIDs not throw promise rejections in the console. Shouldn't have been any problem before, but this is how it's intended to work. Also updated muport-did-resolver with a similar fix.