### PR TITLE
fix(pinning): use correct has metric, optimized open logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "js-sha256": "^0.9.0",
     "multihashes": "^0.4.14",
     "muport-did-resolver": "^0.3.1",
-    "orbit-db": "^0.21.3",
+    "orbit-db": "^0.21.4",
     "orbit-db-cache-redis": "0.0.3",
     "redis": "^2.8.0",
     "url-parse": "^1.4.7",

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -103,6 +103,10 @@ class Pinning {
         const db = entry.db
         delete this.openDBs[address]
         await db.close()
+      } else {
+        // we should still close the DB even if we where not able to open it
+        // otherwise we'll have a memory leak
+        delete this.openDBs[address]
       }
     }
   }
@@ -262,26 +266,24 @@ class Pinning {
 
     if (!this.openDBs[address]) {
       console.log('Opening db:', address)
-      const dbPromise = new Promise(async (resolve, reject) => {
-        const cid = new CID(address.split('/')[2])
-        const opts = {
-          accessController: {
-            type: 'legacy-ipfs-3box',
-            skipManifest: true
-          }
-        }
-        const db = await this.orbitdb.open(address, cid.version === 0 ? opts : {})
-        db.events.on('ready', () => {
-          resolve(db)
-        })
-        db.load()
-      })
-
       this.openDBs[address] = {
-        dbPromise: dbPromise,
-        latestTouch: Date.now(),
-        loading: true
+        dbPromise: new Promise(async (resolve, reject) => {
+          const cid = new CID(address.split('/')[2])
+          const opts = {
+            accessController: {
+              type: 'legacy-ipfs-3box',
+              skipManifest: true
+            }
+          }
+          const db = await this.orbitdb.open(address, cid.version === 0 ? opts : {})
+          db.events.on('ready', () => {
+            resolve(db)
+          })
+          db.load()
+        })
       }
+      this.openDBs[address].latestTouch = Date.now()
+      this.openDBs[address].loading = true
 
       this.openDBs[address].db = await this.openDBs[address].dbPromise
       this.openDBs[address].loading = false
@@ -362,9 +364,8 @@ class Pinning {
   }
 
   _sendHasResponse (address) {
-    const numEntries = this.openDBs[address].db._oplog._length
+    const numEntries = this.openDBs[address].db._oplog.values.length
     this._publish('HAS_ENTRIES', address, numEntries)
-    // console.log('HAS_ENTRIES', address.split('.').pop(), numEntries)
   }
 
   _openSubStores (address) {


### PR DESCRIPTION
This makes the issues we are happen less frequently. It's still hard to say if it will solve it completely though. The main change here is to use `this.openDBs[address].db._oplog.values.length` rather than `this.openDBs[address].db._oplog._length`.  Now it should be consistent with what we are doing in 3box-js.