### PR TITLE
feat: cache has entries and send on message

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "jest": "^23.6.0",
     "nodemon": "^1.19.4",
+    "redis-mock": "^0.47.0",
     "standard": "^14.1.0",
     "supertest": "^4.0.2"
   },

--- a/src/__tests__/pinning.test.js
+++ b/src/__tests__/pinning.test.js
@@ -77,6 +77,8 @@ const cache = {
   write: jest.fn()
 }
 
+jest.mock('redis', () => { return require('redis-mock')})
+
 describe('Pinning', () => {
   let pinning
   let testClient

--- a/src/__tests__/pinning.test.js
+++ b/src/__tests__/pinning.test.js
@@ -99,6 +99,8 @@ describe('Pinning', () => {
       trackSpaceUpdateByApp: jest.fn()
     }
     pinning = new Pinning({ repo: IPFS_PATH_1 }, ODB_PATH_1, analyticsMock, undefined, undefined, PINNING_ROOM)
+
+    pinning._dbOpenedBefore = jest.fn().mockReturnValue(false)
     testClient = new TestClient()
     testClient.onMsg = jest.fn()
     await Promise.all([pinning.start(), testClient.init()])

--- a/src/hasEntriesCache.js
+++ b/src/hasEntriesCache.js
@@ -1,0 +1,25 @@
+const redis = require('redis')
+
+const encode = (value) => (typeof value === 'string' ? value : value.toString())
+const decode = (value) => parseInt(value)
+
+class EntriesCache {
+  constructor (redisOpts = {}) {
+    this.store = redis.createClient(redisOpts)
+  }
+
+  get (key) {
+    return new Promise((resolve, reject) => {
+      this.store.get(key, (err, reply) => {
+        if (err) reject(err)
+        resolve(decode(reply))
+      })
+    })
+  }
+
+  async set (key, value) {
+    this.store.set(key, encode(value))
+  }
+}
+
+module.exports = EntriesCache

--- a/src/hasEntriesCache.js
+++ b/src/hasEntriesCache.js
@@ -1,7 +1,7 @@
 const redis = require('redis')
 
 const encode = (value) => (typeof value === 'string' ? value : value.toString())
-const decode = (value) => parseInt(value)
+const decode = (value) => value ? parseInt(value) : null
 
 class EntriesCache {
   constructor (redisOpts = {}) {

--- a/src/node.js
+++ b/src/node.js
@@ -15,6 +15,7 @@ const IPFS_PATH = process.env.IPFS_PATH
 const SEGMENT_WRITE_KEY = process.env.SEGMENT_WRITE_KEY
 const ANALYTICS_ACTIVE = process.env.ANALYTICS_ACTIVE === 'true'
 const ORBIT_REDIS_PATH = process.env.ORBIT_REDIS_PATH
+const ENTRIES_NUM_REDIS_PATH = process.env.ENTRIES_NUM_REDIS_PATH
 const PUBSUB_REDIS_PATH = process.env.PUBSUB_REDIS_PATH
 const PINNING_ROOM = process.env.PINNING_ROOM || '3box-pinning'
 const HEALTHCHECK_PORT = process.env.HEALTHCHECK_PORT || 8081
@@ -30,6 +31,7 @@ const INSTANCE_ID = randInt(10000000000).toString()
 
 const analyticsClient = analytics(SEGMENT_WRITE_KEY, ANALYTICS_ACTIVE)
 const orbitCacheRedisOpts = ORBIT_REDIS_PATH ? { host: ORBIT_REDIS_PATH } : null
+const entriesNumRedisOpts = ENTRIES_NUM_REDIS_PATH ? { host: ENTRIES_NUM_REDIS_PATH } : null
 const pubSubConfig = PUBSUB_REDIS_PATH && INSTANCE_ID ? { redis: { host: PUBSUB_REDIS_PATH }, instanceId: INSTANCE_ID } : null
 
 function prepareIPFSConfig () {
@@ -57,7 +59,7 @@ function prepareIPFSConfig () {
 
 async function start () {
   const ipfsConfig = prepareIPFSConfig()
-  const pinning = new Pinning(ipfsConfig, ORBITDB_PATH, analyticsClient, orbitCacheRedisOpts, pubSubConfig, PINNING_ROOM)
+  const pinning = new Pinning(ipfsConfig, ORBITDB_PATH, analyticsClient, orbitCacheRedisOpts, pubSubConfig, PINNING_ROOM, entriesNumRedisOpts)
   await pinning.start()
   const healthcheckService = new HealthcheckService(pinning, HEALTHCHECK_PORT)
   healthcheckService.start()


### PR DESCRIPTION
May want to make optional since require redis store, or use a leveldown interface, depends on how we package it up. First required use of another storage layer to run pining node. 

Also sync done based on peers heads will likely be a nicer implementation, but this would have to stay anyways for a while to be backwards compatible with current clients. 

Would cause minor disruption, that the num entries will not be cached first time db is open, thus will send 0 val, which is at least not blocking, but will no reflect sync. But will on following opens. 

TODO 
~~rebase~~
~~tests - need to mock with in memory store~~