### PR TITLE
Feat/283 consistent tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31479,6 +31479,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
+    "lodash.defaultsdeep": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
+      "dev": true
+    },
     "lodash.has": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
@@ -34982,6 +34988,26 @@
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tmp-promise": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.2.tgz",
+      "integrity": "sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==",
+      "dev": true,
+      "requires": {
+        "tmp": "0.1.0"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^2.6.3"
+          }
+        }
       }
     },
     "tmpl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3408,25 +3408,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3436,13 +3440,15 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3452,37 +3458,43 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3491,25 +3503,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3518,13 +3534,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3540,7 +3558,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3554,13 +3573,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3569,7 +3590,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3578,7 +3600,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3588,19 +3611,22 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3609,13 +3635,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3624,13 +3652,15 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3640,7 +3670,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3649,7 +3680,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3658,7 +3690,8 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
@@ -3671,7 +3704,8 @@
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3682,7 +3716,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3700,7 +3735,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3710,13 +3746,15 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3726,7 +3764,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3738,19 +3777,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3759,19 +3801,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3781,19 +3826,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3805,7 +3853,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -3813,7 +3862,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3828,7 +3878,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3837,43 +3888,50 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3884,7 +3942,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3893,7 +3952,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3902,13 +3962,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3923,13 +3985,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3938,13 +4002,15 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true
         }
@@ -31535,9 +31601,9 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "mafmt": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.0.0.tgz",
-      "integrity": "sha512-F13BbCoroi9eS7/arL4xaYIzQq1nMJLU5Tfcpc443jeM+IOI7pLUOBeOqVj/r41uXXDm9azIL/eBnSR1RI9P0Q==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.0.1.tgz",
+      "integrity": "sha512-a/QLhrQiSOTXrfZYGovPETx7BLwwOI5v+OYrQzUllGZ8Q6M5QgRBtCc3dkZcpZfhv6+aRVjFFkhCcmQu4dEwkQ==",
       "requires": {
         "multiaddr": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -53,10 +53,12 @@
   },
   "devDependencies": {
     "jest": "^23.6.0",
+    "lodash.defaultsdeep": "^4.6.1",
     "nodemon": "^1.19.4",
     "redis-mock": "^0.47.0",
     "standard": "^14.1.0",
-    "supertest": "^4.0.2"
+    "supertest": "^4.0.2",
+    "tmp-promise": "^2.0.2"
   },
   "standard": {
     "env": [

--- a/src/__tests__/mock3id.js
+++ b/src/__tests__/mock3id.js
@@ -1,0 +1,43 @@
+const didJWT = require('did-jwt')
+const { registerMethod } = require('did-resolver')
+
+test('', () => {})
+
+const mock3id = {
+  DID: 'did:3:asdfasdf',
+  getKeyringBySpaceName: () => {
+    return {
+      getPublicKeys: () => {
+        return { signingKey: '044f5c08e2150b618264c4794d99a22238bf60f1133a7f563e74fcf55ddb16748159872687a613545c65567d2b7a4d4e3ac03763e1d9a5fcfe512a371faa48a781' }
+      }
+    }
+  },
+  signJWT: payload => {
+    return didJWT.createJWT(payload, {
+      signer: didJWT.SimpleSigner('95838ece1ac686bde68823b21ce9f564bc536eebb9c3500fa6da81f17086a6be'),
+      issuer: 'did:3:asdfasdf'
+    })
+  }
+}
+
+// we need to have a fake 3id resolver since we have a fake 3id
+const registerMock3idResolver = () => registerMethod('3', async () => {
+  return {
+    '@context': 'https://w3id.org/did/v1',
+    id: 'did:3:asdfasdf',
+    publicKey: [{
+      id: 'did:3:asdfasdf#signingKey',
+      type: 'Secp256k1VerificationKey2018',
+      publicKeyHex: '044f5c08e2150b618264c4794d99a22238bf60f1133a7f563e74fcf55ddb16748159872687a613545c65567d2b7a4d4e3ac03763e1d9a5fcfe512a371faa48a781'
+    }],
+    authentication: [{
+      type: 'Secp256k1SignatureAuthentication2018',
+      publicKey: 'did:3:asdfasdf#signingKey'
+    }]
+  }
+})
+
+module.exports = {
+  mock3id,
+  registerMock3idResolver
+}

--- a/src/__tests__/pinning.test.js
+++ b/src/__tests__/pinning.test.js
@@ -1,123 +1,110 @@
-const OrbitDB = require('orbit-db')
-const Pubsub = require('orbit-db-pubsub')
-const {
-  OdbIdentityProvider,
-  LegacyIPFS3BoxAccessController,
-  ThreadAccessController,
-  ModeratorAccessController
-} = require('3box-orbitdb-plugins')
-const Identities = require('orbit-db-identity-provider')
-Identities.addIdentityProvider(OdbIdentityProvider)
-const AccessControllers = require('orbit-db-access-controllers')
-AccessControllers.addAccessController({ AccessController: LegacyIPFS3BoxAccessController })
-AccessControllers.addAccessController({ AccessController: ThreadAccessController })
-AccessControllers.addAccessController({ AccessController: ModeratorAccessController })
-const didJWT = require('did-jwt')
-const { registerMethod } = require('did-resolver')
-const { makeIPFS } = require('./tools')
-
 const Pinning = require('../pinning')
 
-const PINNING_ROOM = '3box-pinning'
-const IPFS_PATH_1 = './tmp/ipfs1'
-const IPFS_PATH_2 = './tmp/ipfs2'
-const ODB_PATH_1 = './tmp/orbitdb1'
-const ODB_PATH_2 = './tmp/orbitdb2'
-
-// Data to be pushed to the store
-const PUBLIC_NAME = { timeStamp: 12000, value: 'very name' }
-const PUBLIC_IMAGE = { timeStamp: 13000, value: 'such picture' }
-const PRIVATE_SHH = { timeStamp: 14000, value: 'many secret' }
-const PRIVATE_QUIET = { timeStamp: 15000, value: 'wow!' }
-
-// const PROFILE_ONLY_VALUES = {
-//   name: PUBLIC_NAME.value,
-//   image: PUBLIC_IMAGE.value
-// }
-
-// const PRIV_IMG_ONLY_VALUES = {
-//   quiet: PRIVATE_QUIET.value,
-//   shh: PRIVATE_SHH.value
-// }
-
-const THREEID_MOCK = {
-  DID: 'did:3:asdfasdf',
-  getKeyringBySpaceName: () => {
-    return {
-      getPublicKeys: () => {
-        return { signingKey: '044f5c08e2150b618264c4794d99a22238bf60f1133a7f563e74fcf55ddb16748159872687a613545c65567d2b7a4d4e3ac03763e1d9a5fcfe512a371faa48a781' }
-      }
-    }
-  },
-  signJWT: payload => {
-    return didJWT.createJWT(payload, {
-      signer: didJWT.SimpleSigner('95838ece1ac686bde68823b21ce9f564bc536eebb9c3500fa6da81f17086a6be'),
-      issuer: 'did:3:asdfasdf'
-    })
-  }
-}
-// we need to have a fake 3id resolver since we have a fake 3id
-const register3idResolver = () => registerMethod('3', async () => {
-  return {
-    '@context': 'https://w3id.org/did/v1',
-    id: 'did:3:asdfasdf',
-    publicKey: [{
-      id: 'did:3:asdfasdf#signingKey',
-      type: 'Secp256k1VerificationKey2018',
-      publicKeyHex: '044f5c08e2150b618264c4794d99a22238bf60f1133a7f563e74fcf55ddb16748159872687a613545c65567d2b7a4d4e3ac03763e1d9a5fcfe512a371faa48a781'
-    }],
-    authentication: [{
-      type: 'Secp256k1SignatureAuthentication2018',
-      publicKey: 'did:3:asdfasdf#signingKey'
-    }]
-  }
-})
-
-const cache = {
-  write: jest.fn()
-}
+const defaultsDeep = require('lodash.defaultsdeep')
+const path = require('path')
+const tmp = require('tmp-promise')
+tmp.setGracefulCleanup()
 
 jest.mock('redis', () => { return require('redis-mock') })
+const TestClient = require('./testClient')
+const { registerMock3idResolver } = require('./mock3id')
+
+// Needed for ipfs spinup/teardown
+jest.setTimeout(15000)
+
+const pinningIpfsConfig = {
+  Bootstrap: [],
+  Addresses: {
+    Swarm: [
+      '/ip4/127.0.0.1/tcp/4002',
+      '/ip4/127.0.0.1/tcp/4003/ws'
+    ]
+  }
+}
+
+const analyticsMock = {
+  trackPinDB: jest.fn(),
+  trackSyncDB: jest.fn(),
+  trackSpaceUpdate: jest.fn(),
+  trackPublicUpdate: jest.fn(),
+  trackRootUpdate: jest.fn(),
+  trackThreadUpdate: jest.fn(),
+  trackPrivateUpdate: jest.fn(),
+  trackPinDBAddress: jest.fn(),
+  trackSpaceUpdateByApp: jest.fn()
+}
+
+const mockProfileData = {
+  public: {
+    name: { timeStamp: 12000, value: 'very name' },
+    image: { timeStamp: 13000, value: 'such picture' }
+  },
+  private: {
+    shh: { timeStamp: 14000, value: 'many secret' },
+    quiet: { timeStamp: 15000, value: 'wow!' }
+  }
+}
+
+const mockThreadEntries = [
+  { message: 'a great post' },
+  { message: 'another great post' }
+]
+
+async function closeAllPinningNodeStores (pinning) {
+  const promises = Object.keys(pinning.openDBs).map(async key => {
+    await pinning.openDBs[key].db.close()
+    delete pinning.openDBs[key]
+  })
+  await Promise.all(promises)
+}
 
 describe('Pinning', () => {
+  let tmpDir
   let pinning
   let testClient
-  let analyticsMock
+  let clientIpfsOpts
 
-  jest.setTimeout(30000)
+  const pinningRoom = 'test-pinning-room'
 
   beforeAll(async () => {
-    analyticsMock = {
-      trackPinDB: jest.fn(),
-      trackSyncDB: jest.fn(),
-      trackSpaceUpdate: jest.fn(),
-      trackPublicUpdate: jest.fn(),
-      trackRootUpdate: jest.fn(),
-      trackThreadUpdate: jest.fn(),
-      trackPrivateUpdate: jest.fn(),
-      trackPinDBAddress: jest.fn(),
-      trackSpaceUpdateByApp: jest.fn()
-    }
-    pinning = new Pinning({ repo: IPFS_PATH_1 }, ODB_PATH_1, analyticsMock, undefined, undefined, PINNING_ROOM)
-    testClient = new TestClient()
-    testClient.onMsg = jest.fn()
-
-    pinning._dbOpenedBefore = jest.fn().mockReturnValue(false)
-    await Promise.all([pinning.start(), testClient.init()])
-
-    register3idResolver()
+    // await registerMock3idResolver()
   })
 
-  beforeEach(() => {
-    testClient.onMsg.mockClear()
-    cache.write.mockClear()
+  beforeEach(async () => {
+    tmpDir = await tmp.dir({ unsafeCleanup: true })
+    const orbitdbPath = tmpDir.path + '/orbitdb'
+    const ipfsPath = tmpDir.path + '/ipfs'
+    const ipfsOpts = {
+      config: pinningIpfsConfig,
+      repo: ipfsPath
+    }
+    const orbitCacheOpts = null
+    const pubSubConfig = null
+    const entriesNumCacheOpts = null
+    const pinWhitelistDids = null
+    const pinWhitelistSpaces = null
+    const pinSilent = null
+
+    pinning = new Pinning(ipfsOpts, orbitdbPath, analyticsMock, orbitCacheOpts, pubSubConfig, pinningRoom, entriesNumCacheOpts, pinWhitelistDids, pinWhitelistSpaces, pinSilent)
+    await pinning.start()
+    const pinningAddresses = await pinning.ipfs.swarm.localAddrs()
+    clientIpfsOpts = { config: { Bootstrap: pinningAddresses } }
+    testClient = new TestClient(clientIpfsOpts, pinningRoom)
+    await testClient.init()
+    await registerMock3idResolver()
+  })
+
+  afterEach(async () => {
+    await testClient.cleanup()
+    await pinning.stop()
+    await tmpDir.cleanup()
   })
 
   it('should sync db correctly from client', async () => {
-    await testClient.createDB(true)
+    await testClient.createDB(mockProfileData)
     const responsesPromise = new Promise((resolve, reject) => {
       const hasResponses = []
-      testClient.onMsg.mockImplementation((topic, data) => {
+      testClient.onMsg = (topic, data) => {
         if (data.type === 'HAS_ENTRIES') {
           expect(data.numEntries).toEqual(0)
           if (hasResponses.indexOf(data.odbAddress) === -1) {
@@ -130,47 +117,87 @@ describe('Pinning', () => {
           expect(hasResponses).toContain(testClient.privStore.address.toString())
           resolve()
         }
-      })
+      }
     })
-    testClient.announceDB()
+    await testClient.announceDB()
     await responsesPromise
-    // wait for stores to sync
-    await new Promise((resolve, reject) => { setTimeout(resolve, 3000) })
-    // TODO
-    // expect(cache.write).toHaveBeenCalledWith('space-list_' + testClient.rootStore.address.toString())
   })
 
-  // TODO
-  // it('should sync db correctly to client', async () => {
-  //   await testClient.reset()
-  //   await closeAllStores(pinning)
-  //   await testClient.createDB(false)
-  //   const responsesPromise = new Promise((resolve, reject) => {
-  //     let hasResponses = []
-  //     testClient.onMsg.mockImplementation((topic, data) => {
-  //       if (data.type === 'HAS_ENTRIES') {
-  //         expect(data.numEntries).toEqual(2)
-  //         hasResponses.push(data.odbAddress)
-  //       }
-  //       if (hasResponses.length === 3) {
-  //         expect(hasResponses).toContain(testClient.rootStore.address.toString())
-  //         expect(hasResponses).toContain(testClient.pubStore.address.toString())
-  //         expect(hasResponses).toContain(testClient.privStore.address.toString())
-  //         resolve()
-  //       }
-  //     })
-  //   })
-  //   await new Promise((resolve, reject) => { setTimeout(resolve, 5000) })
-  //   const dbSyncPromise = testClient.syncDB()
-  //   testClient.announceDB()
-  //   await responsesPromise
-  //   await dbSyncPromise
-  //
-  //   expect(await testClient.getProfile()).toEqual(PROFILE_ONLY_VALUES)
-  //   expect(await testClient.getPrivImg()).toEqual(PRIV_IMG_ONLY_VALUES)
-  // })
+  it('should sync db correctly to client', async () => {
+    // -- Create databases on the pinning node using the test client
+    await testClient.createDB(mockProfileData)
+    const responsesPromise = new Promise((resolve, reject) => {
+      const hasResponses = []
+      testClient.onMsg = (topic, data) => {
+        if (data.type === 'HAS_ENTRIES') {
+          if (hasResponses.indexOf(data.odbAddress) === -1) {
+            hasResponses.push(data.odbAddress)
+          }
+        }
+        if (hasResponses.length === 3) {
+          resolve()
+        }
+      }
+    })
+    await testClient.announceDB()
+    await responsesPromise
+
+    // We have to wait manually for the remote db to sync all entries because we have no sync event
+    await new Promise(resolve => setTimeout(resolve, 3000))
+
+    // -- Create new client with no data
+    const client2IpfsOpts = defaultsDeep({
+      config: {
+        Addresses: {
+          Swarm: [
+            '/ip4/127.0.0.1/tcp/4106',
+            '/ip4/127.0.0.1/tcp/4107/ws'
+          ]
+        }
+      }
+    }, clientIpfsOpts)
+    const testClient2 = new TestClient(client2IpfsOpts, pinningRoom)
+    await testClient2.init()
+
+    // -- Sync new client to pinning node
+    await testClient2.createDB()
+    await testClient2.announceDB()
+    await testClient2.storeSynced()
+
+    const expectedProfile = Object.keys(mockProfileData.public).reduce((acc, key) => {
+      acc[key] = mockProfileData.public[key].value
+      return acc
+    }, {})
+    const expectedPrivate = Object.keys(mockProfileData.private).reduce((acc, key) => {
+      acc[key] = mockProfileData.private[key].value
+      return acc
+    }, {})
+    expect(await testClient2.getProfile()).toEqual(expectedProfile)
+    expect(await testClient2.getPrivate()).toEqual(expectedPrivate)
+    testClient2.cleanup()
+  }, 30000)
 
   it('dbs should close after 30 min, but not before', async () => {
+    await testClient.createDB(mockProfileData)
+    const responsesPromise = new Promise((resolve, reject) => {
+      const hasResponses = []
+      testClient.onMsg = (topic, data) => {
+        if (data.type === 'HAS_ENTRIES') {
+          if (hasResponses.indexOf(data.odbAddress) === -1) {
+            hasResponses.push(data.odbAddress)
+          }
+        }
+        if (hasResponses.length === 3) {
+          resolve()
+        }
+      }
+    })
+    await testClient.announceDB()
+    await responsesPromise
+
+    // We have to wait manually for the remote db to sync all entries because we have no sync event
+    await new Promise(resolve => setTimeout(resolve, 3000))
+
     pinning.checkAndCloseDBs()
     let numOpenDBs = Object.keys(pinning.openDBs).length
     expect(numOpenDBs).toEqual(3)
@@ -192,207 +219,87 @@ describe('Pinning', () => {
   })
 
   describe('Threads', () => {
-    it('should pin thread correctly from client', async () => {
-      await testClient.createThread(true)
+    beforeEach(async () => {
+      await testClient.createDB(mockProfileData)
       const responsesPromise = new Promise((resolve, reject) => {
-        testClient.onMsg.mockImplementation((topic, data) => {
+        const hasResponses = []
+        testClient.onMsg = (topic, data) => {
+          if (data.type === 'HAS_ENTRIES') {
+            if (hasResponses.indexOf(data.odbAddress) === -1) {
+              hasResponses.push(data.odbAddress)
+            }
+          }
+          if (hasResponses.length === 3) {
+            resolve()
+          }
+        }
+      })
+      await testClient.announceDB()
+      await responsesPromise
+
+      // We have to wait manually for the remote db to sync all entries because we have no sync event
+      await new Promise(resolve => setTimeout(resolve, 3000))
+    })
+
+    it('should pin thread correctly from client', async () => {
+      await testClient.createThread(mockThreadEntries)
+      const responsesPromise = new Promise((resolve, reject) => {
+        testClient.onMsg = (topic, data) => {
           if (data.type === 'HAS_ENTRIES') {
             expect(data.numEntries).toEqual(0)
             resolve()
           }
-        })
+        }
       })
-      testClient.announceThread()
+      await testClient.announceThread()
       await responsesPromise
       // wait for thread to sync
       await new Promise((resolve, reject) => { setTimeout(resolve, 5000) })
     })
 
     it('should sync pinned data to client', async () => {
-      await closeAllStores(pinning)
-      await testClient.createThread(false)
+      // -- Create thread on the pinning node using the test client
+      await testClient.createThread(mockThreadEntries)
       const responsesPromise = new Promise((resolve, reject) => {
-        testClient.onMsg.mockImplementation((topic, data) => {
+        testClient.onMsg = (topic, data) => {
           if (data.type === 'HAS_ENTRIES') {
-            expect(data.numEntries).toEqual(2)
             resolve()
           }
-        })
+        }
       })
-      const dbSyncPromise = testClient.syncDB(true)
-      testClient.announceThread()
+      await testClient.announceThread()
       await responsesPromise
-      await dbSyncPromise
-      // for some reason there is an issue with the db not getting fully
-      // replicated in time even after the dbSyncPromise. Wait for 0.5 s
-      await new Promise((resolve, reject) => { setTimeout(resolve, 500) })
-      const posts = await testClient.getThreadPosts()
-      expect(posts[0].message).toEqual('a great post')
-      expect(posts[1].message).toEqual('another great post')
-    })
+
+      // We have to wait manually for the remote db to sync all entries because we have no sync event
+      await new Promise(resolve => setTimeout(resolve, 3000))
+
+      // -- Create new client with no data
+      const client2IpfsOpts = defaultsDeep({
+        config: {
+          Addresses: {
+            Swarm: [
+              '/ip4/127.0.0.1/tcp/4106',
+              '/ip4/127.0.0.1/tcp/4107/ws'
+            ]
+          }
+        }
+      }, clientIpfsOpts)
+      const testClient2 = new TestClient(client2IpfsOpts, pinningRoom)
+      await testClient2.init()
+      await testClient2.createDB()
+      await testClient2.announceDB()
+      await testClient2.createThread()
+      let posts = await testClient2.getThreadPosts()
+      expect(posts).toHaveLength(0)
+
+      // -- Sync new client to pinning node
+      await testClient2.createThread()
+      await testClient2.announceThread()
+      await testClient2.storeSynced({ thread: true })
+      posts = await testClient2.getThreadPosts()
+      expect(posts[0].message).toEqual(mockThreadEntries[0].message)
+      expect(posts[1].message).toEqual(mockThreadEntries[1].message)
+      testClient2.cleanup()
+    }, 30000)
   })
 })
-
-const closeAllStores = async pinning => {
-  const promises = Object.keys(pinning.openDBs).map(async key => {
-    await pinning.openDBs[key].db.close()
-    delete pinning.openDBs[key]
-  })
-  await Promise.all(promises)
-}
-
-class TestClient {
-  constructor () {
-    this.onMsg = () => {}
-  }
-
-  async init () {
-    this.ipfs = await initIPFS()
-    this.identity = await Identities.createIdentity({
-      type: '3ID',
-      threeId: THREEID_MOCK,
-      identityKeysPath: './tmp/odbIdentityKeys'
-    })
-  }
-
-  async createDB (withData) {
-    const ipfsId = await this.ipfs.id()
-    this.orbitdb = await OrbitDB.createInstance(this.ipfs, {
-      directory: ODB_PATH_2,
-      identity: this.identity
-    })
-    this.pubsub = new Pubsub(this.ipfs, ipfsId.id)
-    const key = THREEID_MOCK.getKeyringBySpaceName().getPublicKeys(true).signingKey
-    const opts = {
-      format: 'dag-pb',
-      accessController: {
-        write: [key],
-        type: 'legacy-ipfs-3box',
-        skipManifest: true
-      }
-    }
-    this.rootStore = await this.orbitdb.feed('rs.root', opts)
-    this.pubStore = await this.orbitdb.keyvalue('test.public', opts)
-    this.privStore = await this.orbitdb.keyvalue('test.private', opts)
-    await this.rootStore.add({ odbAddress: this.pubStore.address.toString() })
-    await this.rootStore.add({ odbAddress: this.privStore.address.toString() })
-    if (withData) {
-      await this.pubStore.put('name', PUBLIC_NAME)
-      await this.pubStore.put('image', PUBLIC_IMAGE)
-      await this.privStore.put('shh', PRIVATE_SHH)
-      await this.privStore.put('quiet', PRIVATE_QUIET)
-    }
-  }
-
-  announceDB () {
-    const rootStoreAddress = this.rootStore.address.toString()
-    this.pubsub.subscribe(PINNING_ROOM, this.onMsg.bind(this), () => {
-      this.pubsub.publish(PINNING_ROOM, { type: 'PIN_DB', odbAddress: rootStoreAddress })
-    })
-  }
-
-  async syncDB (thread) {
-    const syncStore = async store => {
-      return new Promise((resolve, reject) => {
-        store.events.on('replicate.progress',
-          (odbAddress, entryHash, entry, num, max) => {
-            if (num === max) {
-              store.events.on('replicated', () => {
-                resolve()
-              })
-            }
-          }
-        )
-      })
-    }
-    if (thread) {
-      await syncStore(this.thread)
-    } else {
-      await Promise.all([
-        syncStore(this.pubStore),
-        syncStore(this.privStore)
-      ])
-    }
-  }
-
-  async createThread (withData) {
-    const tName = '3box.thread.myspace.coolthread'
-    this.thread = await this.orbitdb.feed(tName, {
-      identity: this.identity,
-      accessController: {
-        type: 'thread-access',
-        threadName: tName,
-        members: false,
-        firstModerator: THREEID_MOCK.DID,
-        identity: this.identity
-      }
-    })
-    if (withData) {
-      await this.thread.add({ message: 'a great post' })
-      await this.thread.add({ message: 'another great post' })
-    }
-  }
-
-  async dropThread () {
-    await this.thread.drop()
-  }
-
-  announceThread () {
-    const address = this.thread.address.toString()
-    this.pubsub.publish(PINNING_ROOM, { type: 'SYNC_DB', odbAddress: address, thread: true })
-  }
-
-  async getThreadPosts () {
-    return this.thread
-      .iterator({ limit: -1 })
-      .collect().map(entry => {
-        const post = Object.assign({ postId: entry.hash }, entry.payload.value)
-        return post
-      })
-  }
-
-  async getProfile () {
-    const profile = this.pubStore.all
-    const parsedProfile = {}
-    Object.keys(profile).map(key => { parsedProfile[key] = profile[key].value })
-    return parsedProfile
-  }
-
-  async getPrivImg () {
-    const img = this.privStore.all
-    const parsedProfile = {}
-    Object.keys(img).map(key => { parsedProfile[key] = img[key].value })
-    return parsedProfile
-  }
-
-  async reset () {
-    await Promise.all([
-      this.rootStore.drop(),
-      this.pubStore.drop(),
-      this.privStore.drop()
-    ])
-    await this.orbitdb.stop()
-    await this.pubsub.disconnect()
-  }
-}
-
-const CONF = {
-  EXPERIMENTAL: {
-    pubsub: true
-  },
-  repo: IPFS_PATH_2,
-  config: {
-    Addresses: {
-      Swarm: [
-        '/ip4/127.0.0.1/tcp/4006',
-        '/ip4/127.0.0.1/tcp/4007/ws'
-      ],
-      API: '/ip4/127.0.0.1/tcp/5004',
-      Gateway: '/ip4/127.0.0.1/tcp/9092'
-    }
-  }
-}
-
-const initIPFS = async () => {
-  return makeIPFS(CONF)
-}

--- a/src/__tests__/pinning.test.js
+++ b/src/__tests__/pinning.test.js
@@ -1,6 +1,6 @@
 const Pinning = require('../pinning')
 
-const EventEmitter = require('events');
+const EventEmitter = require('events')
 
 const defaultsDeep = require('lodash.defaultsdeep')
 const tmp = require('tmp-promise')
@@ -57,7 +57,7 @@ function addReplicatedEmitter (pinning) {
   function myOpenDB (address, responseFn, onReplicatedFn, rootStoreAddress, analyticsFn) {
     const newReplicatedFn = (odbAddress) => {
       const numEntries = pinning.openDBs[odbAddress].db._oplog.values.length
-      pinning.events.emit('replicated', {odbAddress, numEntries})
+      pinning.events.emit('replicated', { odbAddress, numEntries })
       if (onReplicatedFn) {
         onReplicatedFn(odbAddress)
       }
@@ -67,8 +67,6 @@ function addReplicatedEmitter (pinning) {
   pinning.openDB = myOpenDB
   return pinning
 }
-
-
 
 describe('Pinning', () => {
   let tmpDir
@@ -279,7 +277,7 @@ describe('Pinning', () => {
           if (!pinningStoreEntries[storeType] || data.numEntries > pinningStoreEntries[storeType]) {
             pinningStoreEntries[storeType] = data.numEntries
           }
-          if (pinningStoreEntries.thread == 2) {
+          if (pinningStoreEntries.thread === 2) {
             pinning.events.off('replicated', checkIfThreadCreated)
             resolve()
           }
@@ -302,7 +300,7 @@ describe('Pinning', () => {
           if (!pinningStoreEntries[storeType] || data.numEntries > pinningStoreEntries[storeType]) {
             pinningStoreEntries[storeType] = data.numEntries
           }
-          if (pinningStoreEntries.thread == 2) {
+          if (pinningStoreEntries.thread === 2) {
             pinning.events.off('replicated', checkIfThreadCreated)
             resolve()
           }

--- a/src/__tests__/pinning.test.js
+++ b/src/__tests__/pinning.test.js
@@ -1,7 +1,6 @@
 const Pinning = require('../pinning')
 
 const defaultsDeep = require('lodash.defaultsdeep')
-const path = require('path')
 const tmp = require('tmp-promise')
 tmp.setGracefulCleanup()
 
@@ -100,10 +99,10 @@ describe('Pinning', () => {
             hasResponses[storeType] = data.numEntries
           }
         }
-        if (Object.keys(hasResponses).length === 3
-            && hasResponses.root == 2
-            && hasResponses.public == Object.keys(mockProfileData.public).length
-            && hasResponses.private == Object.keys(mockProfileData.private).length) {
+        if (Object.keys(hasResponses).length === 3 &&
+            hasResponses.root === 2 &&
+            hasResponses.public === Object.keys(mockProfileData.public).length &&
+            hasResponses.private === Object.keys(mockProfileData.private).length) {
           resolve()
         }
       }
@@ -124,10 +123,10 @@ describe('Pinning', () => {
             hasResponses[storeType] = data.numEntries
           }
         }
-        if (Object.keys(hasResponses).length === 3
-            && hasResponses.root == 2
-            && hasResponses.public == Object.keys(mockProfileData.public).length
-            && hasResponses.private == Object.keys(mockProfileData.private).length) {
+        if (Object.keys(hasResponses).length === 3 &&
+            hasResponses.root === 2 &&
+            hasResponses.public === Object.keys(mockProfileData.public).length &&
+            hasResponses.private === Object.keys(mockProfileData.private).length) {
           resolve()
         }
       }
@@ -178,10 +177,10 @@ describe('Pinning', () => {
             hasResponses[storeType] = data.numEntries
           }
         }
-        if (Object.keys(hasResponses).length === 3
-            && hasResponses.root == 2
-            && hasResponses.public == Object.keys(mockProfileData.public).length
-            && hasResponses.private == Object.keys(mockProfileData.private).length) {
+        if (Object.keys(hasResponses).length === 3 &&
+            hasResponses.root === 2 &&
+            hasResponses.public === Object.keys(mockProfileData.public).length &&
+            hasResponses.private === Object.keys(mockProfileData.private).length) {
           resolve()
         }
       }
@@ -221,10 +220,10 @@ describe('Pinning', () => {
               hasResponses[storeType] = data.numEntries
             }
           }
-          if (Object.keys(hasResponses).length === 3
-              && hasResponses.root == 2
-              && hasResponses.public == Object.keys(mockProfileData.public).length
-              && hasResponses.private == Object.keys(mockProfileData.private).length) {
+          if (Object.keys(hasResponses).length === 3 &&
+              hasResponses.root === 2 &&
+              hasResponses.public === Object.keys(mockProfileData.public).length &&
+              hasResponses.private === Object.keys(mockProfileData.private).length) {
             resolve()
           }
         }
@@ -244,7 +243,7 @@ describe('Pinning', () => {
               hasResponses[storeType] = data.numEntries
             }
           }
-          if (hasResponses.thread == 0) {
+          if (hasResponses.thread === 0) {
             resolve()
           }
         }
@@ -254,12 +253,12 @@ describe('Pinning', () => {
     })
 
     // TODO: reproduce root failure of following tests (see https://github.com/3box/3box-pinning-node/issues/288)
-    it.skip('Test to reproduce error in retrieving the thread access node consecutive times', async() => {
+    it.skip('Test to reproduce error in retrieving the thread access node consecutive times', async () => {
       await testClient.createThread(mockThreadEntries)
       const CID = require('cids')
-      let cid = new CID('zdpuAqS4Qc9Ff3uuUyT6juCpsC7waWw6NDVqtdPYYL9EZRnYx')
+      const cid = new CID('zdpuAqS4Qc9Ff3uuUyT6juCpsC7waWw6NDVqtdPYYL9EZRnYx')
       console.log('STARTING')
-      for (i = 0; i < 10; i++) {
+      for (let i = 0; i < 10; i++) {
         console.log('fetching...', i)
         console.log('MANIFEST', await pinning.ipfs.dag.get(cid))
         // without this delay, consecutive calls fail
@@ -279,7 +278,7 @@ describe('Pinning', () => {
               hasResponses[storeType] = data.numEntries
             }
           }
-          if (hasResponses.thread == 2) {
+          if (hasResponses.thread === 2) {
             resolve()
           }
         }
@@ -301,7 +300,7 @@ describe('Pinning', () => {
               hasResponses[storeType] = data.numEntries
             }
           }
-          if (hasResponses.thread == 2) {
+          if (hasResponses.thread === 2) {
             resolve()
           }
         }

--- a/src/__tests__/pinning.test.js
+++ b/src/__tests__/pinning.test.js
@@ -50,14 +50,6 @@ const mockThreadEntries = [
   { message: 'another great post' }
 ]
 
-async function closeAllPinningNodeStores (pinning) {
-  const promises = Object.keys(pinning.openDBs).map(async key => {
-    await pinning.openDBs[key].db.close()
-    delete pinning.openDBs[key]
-  })
-  await Promise.all(promises)
-}
-
 describe('Pinning', () => {
   let tmpDir
   let pinning
@@ -96,6 +88,7 @@ describe('Pinning', () => {
 
   afterEach(async () => {
     await testClient.cleanup()
+    await pinning.entriesCache.store.flushall()
     await pinning.stop()
     await tmpDir.cleanup()
   })

--- a/src/__tests__/testClient.js
+++ b/src/__tests__/testClient.js
@@ -67,16 +67,6 @@ class TestClient {
     await this._tmpDir.cleanup()
   }
 
-  async reset () {
-    await Promise.all([
-      this.rootStore.drop(),
-      this.pubStore.drop(),
-      this.privStore.drop()
-    ])
-    await this.orbitdb.stop()
-    await this.pubsub.disconnect()
-  }
-
   onMsg () { }
 
   async createDB (withData) {
@@ -102,14 +92,6 @@ class TestClient {
         await this.privStore.put(key, withData.private[key])
       }
     }
-  }
-
-  async dropDB () {
-    await Promise.all([
-      this.rootStore.drop(),
-      this.pubStore.drop(),
-      this.privStore.drop()
-    ])
   }
 
   announceDB () {
@@ -160,11 +142,6 @@ class TestClient {
         await this.thread.add(entry)
       }
     }
-  }
-
-  async dropThread () {
-    await this.thread.drop()
-    await this.thread.close()
   }
 
   async announceThread () {

--- a/src/__tests__/testClient.js
+++ b/src/__tests__/testClient.js
@@ -1,0 +1,199 @@
+const defaultsDeep = require('lodash.defaultsdeep')
+const tmp = require('tmp-promise')
+tmp.setGracefulCleanup()
+
+const OrbitDB = require('orbit-db')
+const Pubsub = require('orbit-db-pubsub')
+const {
+  OdbIdentityProvider,
+  LegacyIPFS3BoxAccessController,
+  ThreadAccessController,
+  ModeratorAccessController
+} = require('3box-orbitdb-plugins')
+const Identities = require('orbit-db-identity-provider')
+Identities.addIdentityProvider(OdbIdentityProvider)
+const AccessControllers = require('orbit-db-access-controllers')
+AccessControllers.addAccessController({ AccessController: LegacyIPFS3BoxAccessController })
+AccessControllers.addAccessController({ AccessController: ThreadAccessController })
+AccessControllers.addAccessController({ AccessController: ModeratorAccessController })
+
+const { makeIPFS } = require('./tools')
+const { mock3id } = require('./mock3id')
+
+class TestClient {
+  constructor (ipfsOpts, pinningRoom) {
+    const defaultIpfsOpts = {
+      config: {
+        Bootstrap: [],
+        Addresses: {
+          Swarm: [
+            '/ip4/127.0.0.1/tcp/4006',
+            '/ip4/127.0.0.1/tcp/4007/ws'
+          ]
+        }
+      }
+    }
+    this._ipfsConfig = defaultsDeep({}, ipfsOpts, defaultIpfsOpts)
+    this._pinningRoom = pinningRoom
+  }
+
+  async init () {
+    this._tmpDir = await tmp.dir({ unsafeCleanup: true })
+    if (!this._ipfsConfig.repo) {
+      this._ipfsConfig.repo = this._tmpDir.path + '/ipfs'
+    }
+    this.ipfs = await makeIPFS(this._ipfsConfig)
+    this.identity = await Identities.createIdentity({
+      type: '3ID',
+      threeId: mock3id,
+      identityKeysPath: this._tmpDir.path + '/odbIdentityKeys'
+    })
+    const ipfsId = await this.ipfs.id()
+    this.orbitdb = await OrbitDB.createInstance(this.ipfs, {
+      directory: this._tmpDir.path + '/orbitdb',
+      identity: this.identity
+    })
+    this.pubsub = new Pubsub(this.ipfs, ipfsId.id)
+  }
+
+  async stop () {
+    await this.pubsub.disconnect()
+    await this.orbitdb.stop()
+    await this.ipfs.stop()
+  }
+
+  async cleanup () {
+    await this.stop()
+    await this._tmpDir.cleanup()
+  }
+
+  async reset () {
+    await Promise.all([
+      this.rootStore.drop(),
+      this.pubStore.drop(),
+      this.privStore.drop()
+    ])
+    await this.orbitdb.stop()
+    await this.pubsub.disconnect()
+  }
+
+  onMsg () { }
+
+  async createDB (withData) {
+    const key = mock3id.getKeyringBySpaceName().getPublicKeys(true).signingKey
+    const opts = {
+      format: 'dag-pb',
+      accessController: {
+        write: [key],
+        type: 'legacy-ipfs-3box',
+        skipManifest: true
+      }
+    }
+    this.rootStore = await this.orbitdb.feed('rs.root', opts)
+    this.pubStore = await this.orbitdb.keyvalue('test.public', opts)
+    this.privStore = await this.orbitdb.keyvalue('test.private', opts)
+    await this.rootStore.add({ odbAddress: this.pubStore.address.toString() })
+    await this.rootStore.add({ odbAddress: this.privStore.address.toString() })
+    if (withData) {
+      for (const key in withData.public) {
+        await this.pubStore.put(key, withData.public[key])
+      }
+      for (const key in withData.private) {
+        await this.privStore.put(key, withData.private[key])
+      }
+    }
+  }
+
+  async dropDB () {
+    await Promise.all([
+      this.rootStore.drop(),
+      this.pubStore.drop(),
+      this.privStore.drop()
+    ])
+  }
+
+  announceDB () {
+    const rootStoreAddress = this.rootStore.address.toString()
+    this.pubsub.subscribe(this._pinningRoom, (...args) => this.onMsg.apply(this, args), () => {
+      this.pubsub.publish(this._pinningRoom, { type: 'PIN_DB', odbAddress: rootStoreAddress })
+    })
+  }
+
+  async storeSynced ({ thread = false } = {}) {
+    const syncStore = async store => {
+      return new Promise((resolve, reject) => {
+        store.events.on('replicate.progress',
+          (odbAddress, entryHash, entry, num, max) => {
+            if (num === max) {
+              store.events.on('replicated', () => {
+                resolve()
+              })
+            }
+          }
+        )
+      })
+    }
+    if (thread) {
+      await syncStore(this.thread)
+    } else {
+      await Promise.all([
+        syncStore(this.pubStore),
+        syncStore(this.privStore)
+      ])
+    }
+  }
+
+  async createThread (withData) {
+    const tName = '3box.thread.myspace.coolthread'
+    this.thread = await this.orbitdb.feed(tName, {
+      identity: this.identity,
+      accessController: {
+        type: 'thread-access',
+        threadName: tName,
+        members: false,
+        firstModerator: mock3id.DID,
+        identity: this.identity
+      }
+    })
+    if (withData) {
+      for (const entry of withData) {
+        await this.thread.add(entry)
+      }
+    }
+  }
+
+  async dropThread () {
+    await this.thread.drop()
+    await this.thread.close()
+  }
+
+  async announceThread () {
+    const address = this.thread.address.toString()
+    await this.pubsub.publish(this._pinningRoom, { type: 'SYNC_DB', odbAddress: address, thread: true })
+  }
+
+  async getThreadPosts () {
+    return this.thread
+      .iterator({ limit: -1 })
+      .collect().map(entry => {
+        const post = Object.assign({ postId: entry.hash }, entry.payload.value)
+        return post
+      })
+  }
+
+  async getProfile () {
+    const profile = this.pubStore.all
+    const parsedProfile = {}
+    Object.keys(profile).map(key => { parsedProfile[key] = profile[key].value })
+    return parsedProfile
+  }
+
+  async getPrivate () {
+    const priv = this.privStore.all
+    const parsedProfile = {}
+    Object.keys(priv).map(key => { parsedProfile[key] = priv[key].value })
+    return parsedProfile
+  }
+}
+
+module.exports = TestClient

--- a/src/messageBroker.js
+++ b/src/messageBroker.js
@@ -17,19 +17,19 @@ class MessageBroker extends Pubsub {
 
   async subscribe (topic, onMessageCallback, onNewPeerCallback) {
     this.messageClientSub.subscribe(topic)
-    super.subscribe(topic, onMessageCallback, onNewPeerCallback)
+    return super.subscribe(topic, onMessageCallback, onNewPeerCallback)
   }
 
   async unsubscribe (topic) {
     this.messageClientSub.unsubscribe(topic)
-    super.unsubscribe(topic)
+    return super.unsubscribe(topic)
   }
 
-  messageHandler (topic, rawMessage) {
+  async messageHandler (topic, rawMessage) {
     const message = messageParse(rawMessage)
     if (message.from === this.instanceId) return
     this.onMessageCallback(topic, message.heads)
-    super.publish(topic, message.heads)
+    return super.publish(topic, message.heads)
   }
 
   onMessageWrap (address, heads) {

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -90,6 +90,7 @@ class Pinning {
     this.pinWhitelistDids = pinWhitelistDids
     this.pinWhitelistSpaces = pinWhitelistSpaces
     this.pinSilent = pinSilent
+    this._intervals = []
   }
 
   async start () {
@@ -119,7 +120,7 @@ class Pinning {
     }
     this.pubsub = new Pubsub(this.ipfs, ipfsId.id)
     await this.pubsub.subscribe(this.pinningRoom, this._onMessage.bind(this), this._onNewPeer.bind(this))
-    setInterval(this.checkAndCloseDBs.bind(this), this.dbCheckCloseInterval)
+    this._intervals.push(setInterval(this.checkAndCloseDBs.bind(this), this.dbCheckCloseInterval))
   }
 
   async stop () {
@@ -127,6 +128,7 @@ class Pinning {
     await this.checkAndCloseDBs()
     await this.orbitdb.stop()
     await this.ipfs.stop()
+    this._intervals.forEach(clearInterval)
   }
 
   async checkAndCloseDBs () {

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -283,7 +283,7 @@ class Pinning {
     const numEntries = this.openDBs[address].db._oplog.values.length
     // 2 lines can be removed in future
     const notCachedBefore = await this.entriesCache.get(address) === null
-    if (notCachedBefore) this._sendHasResponse(address, numEntries)
+    this._sendHasResponse(address, numEntries)
 
     this.entriesCache.set(address, numEntries)
   }

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -282,7 +282,6 @@ class Pinning {
   async _cacheNumEntries (address) {
     const numEntries = this.openDBs[address].db._oplog.values.length
     // 2 lines can be removed in future
-    const notCachedBefore = await this.entriesCache.get(address) === null
     this._sendHasResponse(address, numEntries)
 
     this.entriesCache.set(address, numEntries)

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -90,7 +90,6 @@ class Pinning {
     this.pinWhitelistDids = pinWhitelistDids
     this.pinWhitelistSpaces = pinWhitelistSpaces
     this.pinSilent = pinSilent
-    this._intervals = []
   }
 
   async start () {
@@ -120,15 +119,15 @@ class Pinning {
     }
     this.pubsub = new Pubsub(this.ipfs, ipfsId.id)
     await this.pubsub.subscribe(this.pinningRoom, this._onMessage.bind(this), this._onNewPeer.bind(this))
-    this._intervals.push(setInterval(this.checkAndCloseDBs.bind(this), this.dbCheckCloseInterval))
+    this._dbCloseinterval = setInterval(this.checkAndCloseDBs.bind(this), this.dbCheckCloseInterval)
   }
 
   async stop () {
+    clearInterval(this._dbCloseinterval)
     await this.pubsub.disconnect()
     await this.checkAndCloseDBs()
     await this.orbitdb.stop()
     await this.ipfs.stop()
-    this._intervals.forEach(clearInterval)
   }
 
   async checkAndCloseDBs () {
@@ -335,7 +334,7 @@ class Pinning {
       dataObj.numEntries = data
     } else if (type === 'REPLICATED') {
     }
-    await this.pubsub.publish(this.pinningRoom, dataObj)
+    this.pubsub.publish(this.pinningRoom, dataObj)
   }
 
   _onMessage (topic, data) {

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -118,16 +118,23 @@ class Pinning {
       this.orbitdb._onMessage = messageBroker.onMessageWrap.bind(messageBroker)
     }
     this.pubsub = new Pubsub(this.ipfs, ipfsId.id)
-    this.pubsub.subscribe(this.pinningRoom, this._onMessage.bind(this), this._onNewPeer.bind(this))
+    await this.pubsub.subscribe(this.pinningRoom, this._onMessage.bind(this), this._onNewPeer.bind(this))
     setInterval(this.checkAndCloseDBs.bind(this), this.dbCheckCloseInterval)
   }
 
-  checkAndCloseDBs () {
-    Object.keys(this.openDBs).map(async key => {
+  async stop () {
+    await this.pubsub.disconnect()
+    await this.checkAndCloseDBs()
+    await this.orbitdb.stop()
+    await this.ipfs.stop()
+  }
+
+  async checkAndCloseDBs () {
+    await Promise.all(Object.keys(this.openDBs).map(async key => {
       if (Date.now() > this.openDBs[key].latestTouch + this.dbOpenInterval) {
         await this.dbClose(key)
       }
-    })
+    }))
   }
 
   async dbClose (address) {
@@ -264,7 +271,7 @@ class Pinning {
 
     // line can be removed in future
     if (typeof cacheEntries !== 'number' && await this._dbOpenedBefore(address)) return
-    this._publish('HAS_ENTRIES', address, cacheEntries || 0)
+    await this._publish('HAS_ENTRIES', address, cacheEntries || 0)
   }
 
   async _dbOpenedBefore (address) {
@@ -320,13 +327,13 @@ class Pinning {
     this._openSubStores(address)
   }
 
-  _publish (type, odbAddress, data) {
+  async _publish (type, odbAddress, data) {
     const dataObj = { type, odbAddress }
     if (type === 'HAS_ENTRIES') {
       dataObj.numEntries = data
     } else if (type === 'REPLICATED') {
     }
-    this.pubsub.publish(this.pinningRoom, dataObj)
+    await this.pubsub.publish(this.pinningRoom, dataObj)
   }
 
   _onMessage (topic, data) {

--- a/src/pinning.js
+++ b/src/pinning.js
@@ -282,7 +282,8 @@ class Pinning {
   async _cacheNumEntries (address) {
     const numEntries = this.openDBs[address].db._oplog.values.length
     // 2 lines can be removed in future
-    this._sendHasResponse(address, numEntries)
+    const notCachedBefore = await this.entriesCache.get(address) === null
+    if (notCachedBefore) this._sendHasResponse(address, numEntries)
 
     this.entriesCache.set(address, numEntries)
   }


### PR DESCRIPTION
Only focused on the main pinning tests, since they were the flakey ones.
* TestClient was the biggest part of the test file, so moved it out to its own module
* Also moved into a module code for mocking 3id
* Make test independent - each has its own setup and teardown code, so they can be run individually
* Added some returns of promises in async functions to keep track of running async code
* Create temporary directories inside the tests themselves (clean up where we can, but not required)
