### PR TITLE
test setup: shared datatsore distinct keystore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3010,6 +3010,11 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },
@@ -31898,9 +31903,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
@@ -35856,9 +35861,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
     "ipfs-log": "^4.5.4",
     "ipfs-repo": "^0.30.1",
     "js-sha256": "^0.9.0",
+    "lodash": "^4.17.15",
     "multihashes": "^0.4.14",
     "muport-did-resolver": "^0.3.1",
     "orbit-db": "^0.23.1",
     "orbit-db-cache-redis": "^0.1.2",
     "os-utils": "0.0.14",
-    "redis": "^2.8.0"
+    "redis": "^2.8.0",
+    "uuid": "^3.4.0"
   },
   "jest": {
     "testEnvironment": "node"

--- a/src/__tests__/pubSubWorker.test.js
+++ b/src/__tests__/pubSubWorker.test.js
@@ -1,0 +1,217 @@
+const { PubSubWorker } = require('../pubSubWorker')
+
+const IPFS = require('ipfs')
+const _ = require('lodash')
+const tmp = require('tmp-promise')
+const uuidv4 = require('uuid/v4')
+tmp.setGracefulCleanup()
+
+// The following can be adjusted to test with different number of workers, or to adjust timing
+// parameters
+
+const nWorkers = 10 // At least 3 for tests to pass correctly as written
+
+const workerOpts = {
+  ackDeadline: 150, // this should be greater than combined network delays to ensure consistent queues
+  // ackJitter: 0.2,
+  // processingDeadline: 2000,
+  channelLatencyAllowance: 500 // this should be greater than combined network delays
+}
+
+// Simulate network delays
+const taskAnnounceMaxDelay = 50 // Maximum delay in starting workers usually from external messaging
+const coordinationMaxDelay = 50 // Maximum delay in worker coordination channel
+
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+// Takes a snapshot (static copy) of the worker queues that can be used for comparison later
+const snapshotWorkerQueues = (worker) => {
+  const snapshot = {}
+  for (const taskId in worker.taskQueues) {
+    snapshot[taskId] = {}
+    for (const status in worker.taskQueues[taskId]) {
+      snapshot[taskId][status] = _.cloneDeep(worker.taskQueues[taskId][status]._items)
+    }
+  }
+  return snapshot
+}
+
+describe('pubSubWorker', () => {
+  let tmpDir
+  let ipfs
+  const coordinationTopic = 'test-coordination-topic'
+  let workers
+
+  beforeAll(async () => {
+    tmpDir = await tmp.dir({ unsafeCleanup: true })
+    ipfs = await IPFS.create({ repo: tmpDir.path })
+  })
+
+  afterAll(async () => {
+    tmpDir.cleanup()
+    await ipfs.stop()
+  })
+
+  beforeEach(async () => {
+    workers = Array(nWorkers).fill().map(() => new PubSubWorker(ipfs, coordinationTopic, workerOpts))
+    // Monkeypatch workers to simulate network delay
+    workers.forEach((worker) => {
+      const originalAnnouceFn = worker.announceTask.bind(worker)
+      worker.announceTask = async (...args) => {
+        await delay(Math.random() * taskAnnounceMaxDelay)
+        return originalAnnouceFn(...args)
+      }
+      const originalCoordinationFn = worker._onCoordinationMessage.bind(worker)
+      worker._onCoordinationMessage = async (...args) => {
+        await delay(Math.random() * coordinationMaxDelay)
+        return originalCoordinationFn(...args)
+      }
+    })
+    await Promise.all(workers.map(worker => worker.start()))
+    expect.hasAssertions()
+  })
+
+  afterEach(async () => {
+    await Promise.all(workers.map(async worker => worker.stop()))
+  })
+
+  it('should only process each task once', async () => {
+    expect.assertions(1)
+    const taskId = uuidv4()
+    const taskFn = jest.fn(() => delay(500))
+
+    await Promise.all(workers.map(async worker => worker.announceTask(taskId, taskFn)))
+
+    expect(taskFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should have identical queues amongst workers before they begin processing', async () => {
+    expect.assertions(nWorkers - 1)
+    const taskId = uuidv4()
+    const taskFn = () => delay(500)
+
+    const afterAckWorkerSnapshotsPromise = new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(workers.map(snapshotWorkerQueues))
+      }, workers[0].ackDeadline)
+    })
+
+    await Promise.all(workers.map(async worker => worker.announceTask(taskId, taskFn)))
+
+    const afterAckWorkerSnapshots = await afterAckWorkerSnapshotsPromise
+    afterAckWorkerSnapshots.slice(1).forEach((queue) => {
+      expect(queue).toEqual(afterAckWorkerSnapshots[0])
+    })
+  })
+
+  it('should have identical queues amongst workers after the task has been completed', async () => {
+    expect.assertions(nWorkers - 1)
+    const taskId = uuidv4()
+    const taskFn = () => delay(500)
+
+    await Promise.all(workers.map(async worker => worker.announceTask(taskId, taskFn)))
+
+    const afterCompletedWorkerSnapshots = workers.map(snapshotWorkerQueues)
+    afterCompletedWorkerSnapshots.slice(1).forEach((queue) => {
+      expect(queue).toEqual(afterCompletedWorkerSnapshots[0])
+    })
+  })
+
+  it('should run on the worker that responds first if none have the db open', async () => {
+    expect.assertions(nWorkers)
+    const taskId = uuidv4()
+    const taskFn = () => delay(500)
+    workers.forEach((worker) => {
+      worker.runTaskOpts = {
+        claimProperties: {
+          hasDbOpen: false
+        },
+        claimOrderBy: {
+          fields: ['hasDbOpen', 'timestamp'],
+          orders: ['desc', 'asc']
+        }
+      }
+    })
+    // Need to get the ack timestamp from the snapshots because we only keep the latest state
+    // update timestamp in the queue
+    const afterAckWorkerSnapshotsPromise = new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(workers.map(snapshotWorkerQueues))
+      }, workers[0].ackDeadline)
+    })
+
+    await Promise.all(workers.map(async worker => worker.announceTask(taskId, taskFn, worker.runTaskOpts)))
+
+    // Here we assume all queues are the same, as tested above
+    const afterAckWorkerSnapshots = await afterAckWorkerSnapshotsPromise
+    const completedClaim = workers[0].taskQueues[taskId].COMPLETED._items[0]
+    const completedClaimAckTime = afterAckWorkerSnapshots[0][taskId].ACK.find(claim => claim.workerId === completedClaim.workerId).timestamp
+    afterAckWorkerSnapshots[0][taskId].ACK.forEach((claim) => {
+      expect(completedClaimAckTime).toBeLessThanOrEqual(claim.timestamp)
+    })
+  })
+
+  it('should run on the worker that has the db open if only one does', async () => {
+    expect.assertions(1)
+    const taskId = uuidv4()
+    const taskFn = () => delay(500)
+    workers.forEach((worker) => {
+      worker.runTaskOpts = {
+        claimProperties: {
+          hasDbOpen: false
+        },
+        claimOrderBy: {
+          fields: ['claimProperties.hasDbOpen', 'timestamp'],
+          orders: ['desc', 'asc']
+        }
+      }
+    })
+    const randomWorker = _.sample(workers)
+    randomWorker.runTaskOpts.claimProperties.hasDbOpen = true
+
+    await Promise.all(workers.map(async worker => worker.announceTask(taskId, taskFn, worker.runTaskOpts)))
+
+    const completedClaim = workers[0].taskQueues[taskId].COMPLETED._items[0]
+    console.log(workers[0].taskQueues[taskId].COMPLETED._items)
+    expect(completedClaim.workerId).toEqual(randomWorker.workerId)
+  })
+
+  it('should run on the worker that has the db open and responds first if several have the db open', async () => {
+    expect.assertions(nWorkers * 2)
+    const taskId = uuidv4()
+    const taskFn = () => delay(500)
+    workers.forEach((worker) => {
+      worker.runTaskOpts = {
+        claimProperties: {
+          hasDbOpen: false
+        },
+        claimOrderBy: {
+          fields: ['claimProperties.hasDbOpen', 'timestamp'],
+          orders: ['desc', 'asc']
+        }
+      }
+    })
+    const randomWorkers = _.sampleSize(workers, _.random(2, nWorkers - 1))
+    randomWorkers.forEach(worker => {
+      worker.runTaskOpts.claimProperties.hasDbOpen = true
+    })
+    // Need to get the ack timestamp from the snapshots because we only keep the latest state
+    // update timestamp in the queue
+    const afterAckWorkerSnapshotsPromise = new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(workers.map(snapshotWorkerQueues))
+      }, workers[0].ackDeadline)
+    })
+
+    await Promise.all(workers.map(async worker => worker.announceTask(taskId, taskFn, worker.runTaskOpts)))
+
+    // Here we assume all queues are the same, as tested above
+    const afterAckWorkerSnapshots = await afterAckWorkerSnapshotsPromise
+    const completedClaim = workers[0].taskQueues[taskId].COMPLETED._items[0]
+    const completedClaimAckTime = afterAckWorkerSnapshots[0][taskId].ACK.find(claim => claim.workerId === completedClaim.workerId).timestamp
+    afterAckWorkerSnapshots[0][taskId].ACK.forEach((claim) => {
+      expect(completedClaim.claimProperties.hasDbOpen).toBeTruthy()
+      expect(!claim.claimProperties.hasDbOpen || completedClaimAckTime <= claim.timestamp).toBeTruthy()
+    })
+  })
+})

--- a/src/orbitPubSubExt.js
+++ b/src/orbitPubSubExt.js
@@ -1,0 +1,43 @@
+const OrbitDbPubsub = require('orbit-db-pubsub')
+
+/*
+ *  Extends orbit-db-pubsub to include the message id, as well as provide a configurable
+ *  option on whether we want to process the ipfs node's own messages or not (orbit-db-pubsub
+ *  doesn't process an ipfs node's own messages). This is needed in cases where multiple ipfs
+ *  clients connect to the same ipfs node, and would like to use pubsub to communicate with
+ *  each other.
+ */
+
+class Pubsub extends OrbitDbPubsub {
+  constructor (ipfs, id, { processOwn = false } = {}) {
+    super(ipfs, id)
+    this._processOwn = processOwn
+  }
+
+  async subscribe (topic, onMessageCallback, onNewPeerCallback = () => undefined) {
+    return super.subscribe(topic, onMessageCallback, onNewPeerCallback)
+  }
+
+  async _handleMessage (message) {
+    // Check if we should process our own messages
+    if (!this._processOwn && message.from === this._id) { return }
+
+    // Get the message content and a subscription
+    let content, subscription, topicId, seqno
+    try {
+      // Get the topic
+      topicId = message.topicIDs[0]
+      content = JSON.parse(message.data)
+      subscription = this._subscriptions[topicId]
+      seqno = message.seqno.toString('base64')
+    } catch (error) {
+      console.error('Couldn\'t parse pubsub message:', { message, error })
+    }
+
+    if (subscription && subscription.onMessage && content) {
+      await subscription.onMessage(topicId, content, message.from, seqno)
+    }
+  }
+}
+
+module.exports = Pubsub

--- a/src/pubSubWorker.js
+++ b/src/pubSubWorker.js
@@ -1,0 +1,300 @@
+const EventEmitter = require('events')
+const util = require('util')
+const _ = require('lodash')
+const uuidv4 = require('uuid/v4')
+
+const Pubsub = require('./orbitPubSubExt')
+
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+// Given an ipfs or ipfs client instantiation, this will coordinate with other workers
+// through ipfs/orbitdb pubsub to attempt to run each task exactly once according to a customizable
+// priority. Load balancing could be achieved by using # of dbs open, active connections, load, etc.
+
+class PubSubWorker {
+  /**
+   * The canonical way to instantiate a PubSubWorker
+   * @param  {IPFS|ipfsClient} ipfs - The ipfs instance to use for pubsub
+   * @param  {string} coordinationTopic - The topic name to use for worker coordination messages
+   * @param  {Object} [options]
+   * @param  {Number} [options.workerId] - The unique worker identifier. If not set, generates a new
+   *    uuid
+   * @param  {Number} [options.ackDeadline] - The amount of time (in ms) to wait for other workers
+   *    to acknowledge the task before starting processing. This should balance delay in processing
+   *    a task with ensuring all workers process claims in the same order.
+   * @param  {Number} [options.ackJitter] - The ratio of maximum random additional time to add to
+   *    the ackDeadline, used to minimize chances of workers all responding at the same time
+   * @param  {Number} [options.processingDeadline] - The time limit given to a worker to complete a
+   *    task. Once elapsed, the next claim will be processed.
+   * @param  {Number} [options.channelLatencyAllowance] - The time allowance to process all
+   *    coordination message for a task. This can be more generous than ackDeadline, as otherwise
+   *    entire messages could be ignored, leading to inconsistent state across workers. However,
+   *    longer allowances will keep resources open for longer.
+   * @return {PubSubWorker}
+   */
+  static async create (...args) {
+    const worker = new PubSubWorker(...args)
+    await worker.start()
+    return worker
+  }
+
+  constructor (ipfs, coordinationTopic, { workerId, ackDeadline = 500, ackJitter = 0.2, processingDeadline = 5000, channelLatencyAllowance = 2000 } = {}) {
+    this.ipfs = ipfs
+    this.workerId = workerId || uuidv4()
+    this.coordinationTopic = coordinationTopic
+    this.ackDeadline = ackDeadline
+    this.processingDeadline = processingDeadline
+    this.channelLatencyAllowance = channelLatencyAllowance
+    this.ackJitter = ackJitter
+    this.taskQueues = {}
+    this._undefinedTasks = {}
+  }
+
+  async start () {
+    console.log('Starting PubSubWorker', this.workerId)
+    const ipfsId = await this.ipfs.id()
+    this.pubsub = new Pubsub(this.ipfs, ipfsId.id, { processOwn: true })
+    await this.pubsub.subscribe(this.coordinationTopic, this._onCoordinationMessage.bind(this), this._onNewPeer.bind(this))
+  }
+
+  async stop () {
+    console.log('Stopping PubSubWorker', this.workerId)
+    await this.pubsub.disconnect()
+  }
+
+  /**
+   * Announce a task, to be processed by this or another worker
+   * @param  {string} taskId - A unique identifier for the task. Must be consistent across workers
+   * @param  {function} taskFn - The function to call to execute the task
+   * @param  {Object} options
+   * @param  {Object} options.claimProperties - Additional properties to be added to the claim,
+   *    which can then be used to prioritize claims
+   * @param  {Object} options.claimOrderBy - The order in which to prioritize claims
+   * @param  {string[]} options.claimOrderBy.fields - The paths of the claim objects to order by
+   * @param  {string[]} options.claimOrderBy.orders - The orders in which to prioritize the fields.
+   *    (possible values: 'asc', 'desc')
+   */
+  async announceTask (taskId, taskFn, { claimProperties, claimOrderBy = { fields: ['timestamp'], orders: ['asc'] } } = {}) {
+    this.taskQueues[taskId] = {
+      ACK: new PriorityQueue(claimOrderBy.fields, claimOrderBy.orders),
+      PROCESSING: new PriorityQueue(claimOrderBy.fields, claimOrderBy.orders),
+      COMPLETED: new PriorityQueue(claimOrderBy.fields, claimOrderBy.orders)
+    }
+    if (taskId in this._undefinedTasks) {
+      this._undefinedTasks[taskId].emit('defined')
+      delete this._undefinedTasks[taskId]
+    }
+    const claimsQueue = this.taskQueues[taskId]
+
+    const claimData = {
+      timestamp: Date.now(),
+      taskId,
+      workerId: this.workerId,
+      claimProperties
+    }
+    this.pubsub.publish(this.coordinationTopic, {
+      status: 'ACK',
+      ...claimData
+    })
+
+    // Loop through the acknowledged claims until we come to our own claim
+    while (true) {
+      // Wait between claims to allow the worker whose claim it is to process it
+      // add jitter so not all workers respond at the same time
+      await delay(this.ackDeadline * (1 + (Math.random() * this.ackJitter)))
+
+      // Check if the task is completed or already being processed
+      if (claimsQueue.COMPLETED.length > 0) {
+        // Done: task was completed by another worker
+        break
+      } else if (claimsQueue.PROCESSING.length > 0) {
+        // Another worker(s) is processing the task; Let it finish/expire
+        await new Promise((resolve, reject) => {
+          function resolveAndCleanup () {
+            claimsQueue.PROCESSING.events.removeListener('empty', resolveAndCleanup)
+            claimsQueue.PROCESSING.events.removeListener('stop', resolveAndCleanup)
+            resolve()
+          }
+          claimsQueue.PROCESSING.events.on('empty', resolveAndCleanup)
+          claimsQueue.PROCESSING.events.on('stop', resolveAndCleanup)
+        })
+      } else {
+        // No-one is processing this task yet; get the next worker in the priority queue
+        let nextClaim
+        try {
+          nextClaim = claimsQueue.ACK.pop()
+        } catch (err) {
+          console.error('something has gone terribly wrong: ACK queue is empty, and we didn\'t process our own claim', { err })
+          return
+        }
+
+        if (nextClaim.workerId === this.workerId) {
+          // This is us, publish and process
+          this.pubsub.publish(this.coordinationTopic, {
+            status: 'PROCESSING',
+            ...claimData,
+            timestamp: Date.now()
+          })
+
+          // We don't keep the results, because we don't use it now, and this would involve more
+          // message passing - implement later if needed
+          await taskFn()
+
+          this.pubsub.publish(this.coordinationTopic, {
+            status: 'COMPLETED',
+            ...claimData,
+            timestamp: Date.now()
+          })
+          break
+        }
+        // This wasn't us - loop to check if this claim was processed by its worker
+      }
+    }
+    // send stop event to clean up listeners
+    for (const status of ['ACK', 'PROCESSING', 'COMPLETED']) {
+      claimsQueue[status].stop()
+    }
+    // Return immediately, but delay before deleting the queue in case more coordination messages
+    // come in, we at least register them
+    setTimeout(() => {
+      if (claimsQueue.COMPLETED.length > 1) {
+        // TODO: this is an important metric to track
+        console.warn(`more than one worker completed task: ${taskId}`)
+      }
+      delete this.taskQueues[taskId]
+    }, this.channelLatencyAllowance)
+  }
+
+  async _onCoordinationMessage (topicId, data) {
+    const status = data.status
+    const timestamp = data.timestamp
+    const taskId = data.taskId
+    const workerId = data.workerId
+    const claimProperties = data.claimProperties
+
+    const claimsQueue = await this._waitForTaskQueue(taskId)
+
+    if (status === 'ACK') {
+      claimsQueue.ACK.insert({ workerId, timestamp, claimProperties })
+    } else if (status === 'PROCESSING') {
+      claimsQueue.ACK.removeFirstBy(claim => claim.workerId === workerId)
+      claimsQueue.PROCESSING.insert({ workerId, timestamp, claimProperties })
+      // Remove after processing deadline
+      setTimeout(() => {
+        claimsQueue.PROCESSING.removeFirstBy(claim => claim.workerId === workerId)
+      }, this.processingDeadline)
+    } else if (status === 'COMPLETED') {
+      claimsQueue.ACK.removeFirstBy(claim => claim.workerId === workerId)
+      claimsQueue.PROCESSING.removeFirstBy(claim => claim.workerId === workerId)
+      claimsQueue.COMPLETED.insert({ workerId, timestamp, claimProperties })
+    }
+  }
+
+  // If a message comes in for a task we don't have registered, wait for it to be created (or time
+  // out)
+  async _waitForTaskQueue (taskId) {
+    if (!this.taskQueues[taskId]) {
+      if (!this._undefinedTasks[taskId]) {
+        this._undefinedTasks[taskId] = new EventEmitter()
+      }
+      await new Promise((resolve, reject) => {
+        this._undefinedTasks[taskId].once('defined', resolve)
+        setTimeout(() => {
+          if (taskId in this._undefinedTasks) {
+            this._undefinedTasks[taskId].off('defined', resolve)
+          }
+        }, this.channelLatencyAllowance)
+      })
+        .finally(() => delete this._undefinedTasks[taskId])
+    }
+    if (!this.taskQueues[taskId]) {
+      throw new Error(`got coordination msg for task that doesn't have a queue: ${taskId}`)
+    }
+    return this.taskQueues[taskId]
+  }
+
+  async _onNewPeer (topic, peer) {
+    console.log('new peer joined coordination topic', { topic, peer })
+  }
+}
+
+// Simple priority queue that orders items by fields
+// Follows interface used by lodash orderBy: https://lodash.com/docs/4.17.15#orderBy
+class PriorityQueue {
+  constructor (fields, orders) {
+    this._items = []
+    this._comparator = PriorityQueue._comparatorByFields(fields, orders)
+    this.events = new EventEmitter()
+  }
+
+  insert (item) {
+    let index = this._items.findIndex(it => this._comparator(item, it))
+    if (index === -1) {
+      index = this._items.length
+    }
+    this._items.splice(index, 0, item)
+    return this._items.length - 1
+  }
+
+  pop () {
+    if (this._items.length === 0) {
+      throw new Error('no items in queue')
+    }
+    const result = this._items.shift()
+    if (this._items.length === 0) {
+      this.events.emit('empty')
+    }
+    return result
+  }
+
+  removeFirstBy (predicate) {
+    const index = this._items.findIndex(predicate)
+    if (index !== -1) {
+      const removed = this._items.splice(index, 1)
+      if (this._items.length === 0) {
+        this.events.emit('empty')
+      }
+      return removed[0]
+    }
+  }
+
+  get length () {
+    return this._items.length
+  }
+
+  inspect (depth, opts) {
+    return util.inspect(this._items)
+  }
+
+  stop () {
+    this.events.emit('stop')
+  }
+
+  static _comparatorByFields (fields, orders) {
+    // Add tie breaker to make sure all workers have the same ordering
+    fields = [...fields, 'workerId']
+    orders = [...orders, 'asc']
+    return function (a, b) {
+      for (const [field, order] of _.zip(fields, orders)) {
+        const valA = _.get(a, field)
+        const valB = _.get(b, field)
+        if (valA !== valB) {
+          if (order === 'asc') {
+            return valA < valB
+          } else if (order === 'desc') {
+            return valA > valB
+          } else {
+            throw new Error(`Unexpected order value: '${order}'`)
+          }
+        }
+      }
+      // Default - would only get here if all fields including workerId are identical
+      return true
+    }
+  }
+}
+
+module.exports = {
+  createWorker: PubSubWorker.create,
+  PubSubWorker
+}

--- a/src/s3.js
+++ b/src/s3.js
@@ -17,6 +17,7 @@ const notALock = {
 
 const ipfsRepo = (config) => {
   const {
+    nodeId,
     path,
     bucket,
     accessKeyId,
@@ -27,10 +28,26 @@ const ipfsRepo = (config) => {
   } = config
   const createIfMissing = true
 
-  const storeConfig = {
+  console.log({nodeId})
+
+  const sharedStoreConfig = {
     s3: new S3({
       params: {
         Bucket: bucket
+      },
+      accessKeyId,
+      secretAccessKey,
+      endpoint,
+      s3ForcePathStyle,
+      signatureVersion
+    }),
+    createIfMissing
+  }
+
+  const selfStoreConfig = {
+    s3: new S3({
+      params: {
+        Bucket: nodeId ? `node-${nodeId}` : bucket
       },
       accessKeyId,
       secretAccessKey,
@@ -49,10 +66,10 @@ const ipfsRepo = (config) => {
       keys: S3Store
     },
     storageBackendOptions: {
-      blocks: storeConfig,
-      datastore: storeConfig,
-      root: storeConfig,
-      keys: storeConfig
+      blocks: sharedStoreConfig,
+      datastore: selfStoreConfig,
+      root: selfStoreConfig,
+      keys: selfStoreConfig
     },
     lock: notALock
   })


### PR DESCRIPTION
This includes the compose orchestrations to be used for the tests defined in https://www.notion.so/threebox/Test-plan-for-pinning-architecture-ff3e1a6d28ca45b5b898f3414795ad96

--------

- 2 new compose files:
  - 2 pinning nodes (orbit + ipfs) with shared blockstore, other datastores path based on NODE_ID env vra
  - 2 pinning nodes + 2 separate ipfs nodes, shared blockstore as above
