### PR TITLE
change max connections from 500 to 1500

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -75,6 +75,12 @@ function prepareIPFSConfig () {
       Bootstrap: [],
       Addresses: {
         Swarm: swarmAddresses
+      },
+      Swarm: {
+        ConnMgr: {
+          LowWater: 700,
+          HighWater: 1500
+        }
       }
     }
   }


### PR DESCRIPTION
Once HighWater connections are reached, ipfs will garbage collect connections until LowWater is reached.

Defaults are 200/500