### PR TITLE
feat(pinning): re-enable healthcheck route

### DIFF
--- a/src/__tests__/healthcheckService.test.js
+++ b/src/__tests__/healthcheckService.test.js
@@ -26,34 +26,34 @@ describe('HealthcheckService', () => {
     isOnlineMock.mockRestore()
   })
 
-  // it('should return a failure if IPFS isn\'t online', async (done) => {
-  //   isOnlineMock.mockReturnValue(false)
-  //
-  //   request(healthcheckService.app)
-  //     .get('/healthcheck')
-  //     .expect(503)
-  //     .end(done)
-  // })
+  it('should return a failure if IPFS isn\'t online', async (done) => {
+    isOnlineMock.mockReturnValue(false)
 
-  // it('should return a failure on low cpu', async (done) => {
-  //   cpuFreeMock.mockImplementation(cb => cb(0.01)) // eslint-disable-line standard/no-callback-literal
-  //
-  //   request(healthcheckService.app)
-  //     .get('/healthcheck')
-  //     .expect(503)
-  //     .end(done)
-  // })
+    request(healthcheckService.app)
+      .get('/healthcheck')
+      .expect(503)
+      .end(done)
+  })
 
-  // it('should return a failure on low memory', async (done) => {
-  //   freememPercentageMock.mockReturnValue(0.01)
-  //
-  //   request(healthcheckService.app)
-  //     .get('/healthcheck')
-  //     .expect(503)
-  //     .end(done)
-  // })
+  it('should return a failure on low cpu', async (done) => {
+    cpuFreeMock.mockImplementation(cb => cb(0.01)) // eslint-disable-line standard/no-callback-literal
 
-  it('should return a succes if memory, cpu and IPFS status are OK', async (done) => {
+    request(healthcheckService.app)
+      .get('/healthcheck')
+      .expect(503)
+      .end(done)
+  })
+
+  it('should return a failure on low memory', async (done) => {
+    freememPercentageMock.mockReturnValue(0.01)
+
+    request(healthcheckService.app)
+      .get('/healthcheck')
+      .expect(503)
+      .end(done)
+  })
+
+  it('should return a success if memory, cpu and IPFS status are OK', async (done) => {
     request(healthcheckService.app)
       .get('/healthcheck')
       .expect(200)

--- a/src/healthcheckService.js
+++ b/src/healthcheckService.js
@@ -23,9 +23,6 @@ class HealthcheckService {
     if (cpuFree < 0.05 || memFree < 0.20) {
       return res.status(503).send()
     }
-    if (memFree < 0.20) {
-      return res.status(503).send()
-    }
     return res.status(200).send()
   }
 

--- a/src/healthcheckService.js
+++ b/src/healthcheckService.js
@@ -15,7 +15,9 @@ class HealthcheckService {
   }
 
   async healthcheckHandler (req, res, next) {
-    if (!this.pinning.ipfs.isOnline()) return res.status(503).send()
+    if (!this.pinning.ipfs.isOnline()) {
+      return res.status(503).send()
+    }
     const cpuFree = await new Promise((resolve, reject) => os.cpuFree(resolve))
     const memFree = os.freememPercentage()
     if (cpuFree < 0.05 || memFree < 0.20) {
@@ -24,6 +26,7 @@ class HealthcheckService {
     if (memFree < 0.20) {
       return res.status(503).send()
     }
+    return res.status(200).send()
   }
 
   start () {

--- a/src/healthcheckService.js
+++ b/src/healthcheckService.js
@@ -1,5 +1,5 @@
 const express = require('express')
-// const os = require('os-utils')
+const os = require('os-utils')
 
 const { createLogger } = require('./logger')
 
@@ -15,12 +15,15 @@ class HealthcheckService {
   }
 
   async healthcheckHandler (req, res, next) {
-    // if (!this.pinning.ipfs.isOnline()) return res.status(503).send()
-    // const cpuFree = await new Promise((resolve, reject) => os.cpuFree(resolve))
-    // const memFree = os.freememPercentage()
-    // if (cpuFree < 0.05 || memFree < 0.20) return res.status(503).send()
-    // if (memFree < 0.20) return res.status(503).send()
-    return res.status(200).send()
+    if (!this.pinning.ipfs.isOnline()) return res.status(503).send()
+    const cpuFree = await new Promise((resolve, reject) => os.cpuFree(resolve))
+    const memFree = os.freememPercentage()
+    if (cpuFree < 0.05 || memFree < 0.20) {
+      return res.status(503).send()
+    }
+    if (memFree < 0.20) {
+      return res.status(503).send()
+    }
   }
 
   start () {


### PR DESCRIPTION
- previous `healthcheck` logic is OK. Re-enable it.